### PR TITLE
feat(pre-commit): conventional commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,6 +6,12 @@ repos:
       - id: trailing-whitespace
       - id: check-yaml
         args: [--allow-multiple-documents]
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v3.1.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []
 
 
   - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,10 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: []
+        args: [
+          --strict,
+          --force-scope
+        ]
 
 
   - repo: local


### PR DESCRIPTION
introducing, conventional commit pre-commit hook

- https://github.com/compilerla/conventional-pre-commit
- https://www.conventionalcommits.org/en/v1.0.0/

enforces the conventional commit standard for all commit messages